### PR TITLE
chore: package.jsonにnameを追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+    "name": "basta",
     "private": true,
     "scripts": {
         "dev": "vite",


### PR DESCRIPTION
本番環境内で、package-lock.jsonのnameの値が書き変わってしまう原因が、package.jsonのnameが記載されていないことかもしれないということがわかったため。