### PR TITLE
fix: Larastanによって指摘された、メソッドが返す型が宣言した型と違うエラーを修正

### DIFF
--- a/app/Http/Controllers/RegisteredUserController.php
+++ b/app/Http/Controllers/RegisteredUserController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Models\Role;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Contracts\Auth\StatefulGuard;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Facades\Auth;
@@ -54,10 +55,8 @@ class RegisteredUserController extends Controller
 
     /**
      * Create a new registered user（運営権限のユーザーとして登録）.
-     *
-     * @return \Laravel\Fortify\Contracts\RegisterResponse
      */
-    public function storeAdmin(Request $request, CreatesNewUsers $creator)
+    public function storeAdmin(Request $request, CreatesNewUsers $creator): RedirectResponse
     {
         // 運営トップ権限ユーザーであることを確認（Gateで）
         if (! Gate::allows('admin-top', Auth::user())) {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,7 +7,7 @@ parameters:
         - app/
         - tests/
 
-    level: 2
+    level: 3
 
     excludePaths:
         - tests/TestCase.php


### PR DESCRIPTION
## やったこと

* LarastanのレベルをLevel 2からLevel 3に上げた
* Level 3で検出された型の不一致エラーを修正
  * `RegisteredUserController::storeAdmin()` メソッドの戻り値型を実装に合わせて正確に定義
  * 不要なPHPDocの `@return` タグを削除
  * `Illuminate\Http\RedirectResponse` のuseステートメントを追加

## やらないこと

* 無し

## できるようになること（ユーザ目線）

* 無し（内部的なコード品質向上のため、ユーザーへの機能的な影響はなし）

## できなくなること（ユーザ目線）

* 無し

## 動作確認

* Larastan Level 3での静的解析が正常に通ることを確認
* 修正前：2つのエラーが検出されていた
* 修正後：エラーが解消され、Level 3での解析が成功することを確認

## その他

* 今回の修正は型安全性の向上が目的で、実際の動作に変更はありません
* `storeAdmin` メソッドは実装上常に `RedirectResponse` を返すため、型定義を実装に合わせて正確にしました
* 段階的にLarastanのレベルを上げて品質向上を図っています