### PR TITLE
chore: Larastanのレベルを4から5に上げ、静的解析で検出されたエラーを修正

### DIFF
--- a/app/Actions/Fortify/UpdateUserProfileInformation.php
+++ b/app/Actions/Fortify/UpdateUserProfileInformation.php
@@ -13,7 +13,7 @@ class UpdateUserProfileInformation implements UpdatesUserProfileInformation
     /**
      * Validate and update the given user's profile information.
      *
-     * @param  array<string, string>  $input
+     * @param  array<string, mixed>  $input
      */
     public function update(User $user, array $input): void
     {
@@ -43,7 +43,7 @@ class UpdateUserProfileInformation implements UpdatesUserProfileInformation
     /**
      * Update the given verified user's profile information.
      *
-     * @param  array<string, string>  $input
+     * @param  array<string, mixed>  $input
      */
     protected function updateVerifiedUser(User $user, array $input): void
     {

--- a/app/Mail/SendRequestMail.php
+++ b/app/Mail/SendRequestMail.php
@@ -50,7 +50,8 @@ class SendRequestMail extends Mailable
         return new Envelope(
             subject: $subject,
             from: Auth::user()->email,
-            to: 'basta.h.a.132@gmail.com',
+            // PHPStan のエラー回避のため、配列で指定しました
+            to: ['basta.h.a.132@gmail.com'],
         );
     }
 

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -9,6 +9,9 @@ use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Str;
 use Laravel\Jetstream\Features;
 
+/**
+ * @extends Factory<User>
+ */
 class UserFactory extends Factory
 {
     /**

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,7 +7,7 @@ parameters:
         - app/
         - tests/
 
-    level: 4
+    level: 5
 
     excludePaths:
         - tests/TestCase.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -13,16 +13,6 @@ parameters:
         - tests/TestCase.php
 
     ignoreErrors:
-        # テストでのEloquentファクトリの型推論エラーを無視
-        -
-            message: '#Access to an undefined property Illuminate\\Database\\Eloquent\\Model::\$\w+#'
-            paths:
-                - tests/**/*.php
-        -
-            message: '#Call to an undefined method Illuminate\\Database\\Eloquent\\Model::\w+\(\)#'
-            paths:
-                - tests/**/*.php
-
         # Laravel Socialite関連の型定義不備を無視
         -
             message: '#Call to an undefined method Laravel\\Socialite\\Contracts\\Provider::(with|redirectUrl)\(\)#'


### PR DESCRIPTION
## やったこと

* PHPstanの解析レベルを4から5に引き上げ
* PHPstan レベル5で発生する155個のエラーをすべて解決
* `UserFactory`に適切な型アノテーションを追加（`@extends Factory<User>`）
* `SendRequestMail`クラスの`Envelope`使用方法を型安全な方式に修正
* `UpdateUserProfileInformation`クラスの型アノテーションを実際のデータ構造に合わせて修正

## やらないこと

無し

## できるようになること（ユーザ目線）

無し（内部的なコード品質改善のため、ユーザー向け機能に変更なし）

## できなくなること（ユーザ目線）

無し

## 動作確認

* **PHPstan解析**: レベル5で全155エラーが0エラーに解決されることを確認
* **既存テスト**: 既存のテストコードが引き続き正常に動作することを確認
* **メール送信機能**: `SendRequestMail`の送信先指定方法変更後も正常に動作することを確認

## その他

### 主要な修正内容

1. **UserFactory型推論改善**
   - `@extends Factory<User>`アノテーション追加により、`User::factory()->create()`の戻り値が`User`型として正しく推論されるようになった
   - これにより150+個の`actingAs`関連エラーが一挙に解決

2. **Envelope型安全性向上**
   - `to`パラメータを文字列から配列形式に変更
   - Laravel Mail の型定義に準拠した実装に修正

3. **型アノテーション精度向上**
   - `array<string, string>` → `array<string, mixed>`に変更
   - `UploadedFile`オブジェクトを含む実際のデータ構造に対応

### 技術的メリット
- 静的解析による早期バグ発見が可能
- 型安全性の向上により保守性が大幅に改善
- IDE補完の精度向上
- リファクタリング時の安全性確保