### PR TITLE
fix: ログイン画面と新規登録画面のレスポンシブ用のUIを調整

### DIFF
--- a/resources/views/components/authentication-card-logo.blade.php
+++ b/resources/views/components/authentication-card-logo.blade.php
@@ -2,5 +2,5 @@
     @can('admin-top'){{ route('admin.user_top') }}
     @else {{ route('index') }}
     @endcan">
-    <img src="{{ asset('images/logo.png') }}" alt="">
+    <img src="{{ asset('images/logo.png') }}" alt="" class="mx-auto w-28 h-28 sm:w-40 sm:h-40">
 </a>

--- a/resources/views/components/authentication-card.blade.php
+++ b/resources/views/components/authentication-card.blade.php
@@ -1,18 +1,18 @@
-<div class="flex flex-col items-center min-h-screen pt-6 bg-gray-100 sm:justify-center sm:pt-0">
+<div class="flex flex-col items-center pt-6 min-h-screen bg-gray-100 sm:justify-center sm:pt-0">
     <x-flash-message status="error" />
     <div>
         {{ $logo }}
     </div>
 
-    <div class="w-full px-6 py-4 mt-6 overflow-hidden bg-white shadow-md sm:max-w-md sm:rounded-lg">
+    <div class="overflow-hidden px-6 py-4 mt-6 w-full bg-white shadow-md sm:max-w-md sm:rounded-lg">
         {{ $slot }}
     </div>
 
     {{-- 新規登録画面でGoogleログインを表示されないようにするために記載 --}}
     @if(Route::is('login'))
     <a href="{{ route('auth.google') }}"
-        class="flex items-center justify-center px-32 py-3 mt-8 text-lg font-bold text-gray-700 bg-white border border-gray-700 rounded-md hover:bg-gray-100">
-        <img src="/images/google.png" alt="Google" class="w-6 h-6 mr-2">Googleでログイン
+        class="flex justify-center items-center px-16 py-3 mt-8 text-base font-bold text-gray-700 bg-white rounded-md border border-gray-700 sm:text-lg sm:px-32 hover:bg-gray-100">
+        <img src="/images/google.png" alt="Google" class="mr-2 w-5 h-5 sm:w-6 sm:h-6">Googleでログイン
     </a>
     @endif
 </div>


### PR DESCRIPTION
## やったこと

* 認証カードのロゴ画像のサイズを画面サイズに応じて調整（モバイル: 28x28、デスクトップ: 40x40）
* Googleログインボタンのパディングとテキストサイズをレスポンシブに調整
* Googleアイコンのサイズをモバイルとデスクトップで最適化

## やらないこと

* 他の認証関連ページ（パスワードリセット、メール確認など）のレスポンシブ対応（今回は対象外）

## できるようになること（ユーザ目線）

* モバイルデバイスでログイン・サインアップページがより見やすく操作しやすくなる

## できなくなること（ユーザ目線）

* 無し

## 動作確認

Chromeのデベロッパーツールで目視で確認

## その他

* 無し