### PR TITLE
fix: iOSでinputのfocus時にズームインしてしまう問題を修正

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers;
 
+use Illuminate\Routing\UrlGenerator;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -21,5 +22,10 @@ class AppServiceProvider extends ServiceProvider
      *
      * @return void
      */
-    public function boot() {}
+    public function boot(UrlGenerator $url)
+    {
+        if (env('APP_ENV') === 'ngrok') {
+            $url->forceScheme('https');
+        }
+    }
 }

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -3,14 +3,14 @@
 
 <head>
     <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="viewport" content="width=device-width,initial-scale=1.0,maximum-scale=1.0">
     <meta name="csrf-token" content="{{ csrf_token() }}">
 
     <title>{{ config('app.name', 'Laravel') }}</title>
 
     <!-- Fonts -->
     <link rel="preconnect" href="https://fonts.bunny.net">
-    <link href="https://fonts.bunny.net/css?family=figtree:400,500,600&display=swap" rel="stylesheet" />    
+    <link href="https://fonts.bunny.net/css?family=figtree:400,500,600&display=swap" rel="stylesheet" />
     <script src="https://kit.fontawesome.com/8e73e32fc5.js" crossorigin="anonymous"></script>
     <link rel="stylesheet"
         href="https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200" />


### PR DESCRIPTION
## やったこと

* iOSデバイスでの入力フィールドタップ時の自動ズーム問題を修正
* viewportメタタグに`maximum-scale=1.0`を追加してズームを制限
* ngrok環境でのHTTPS強制設定を追加（開発環境の改善）

## やらないこと

* 無し

## できるようになること（ユーザ目線）

* iOSデバイスでメモ作成やコメント入力時に、画面が勝手にズームインしなくなる
* より快適にモバイルデバイスでアプリを利用できる

## できなくなること（ユーザ目線）

* 自動ズームされなくなったことによるアクセシビリティの低下

## 動作確認

* iOSデバイス（iPhone）でアプリにアクセスし、各検索欄などをタップし、画面の自動ズームが発生しないことを確認

## その他

* iOSのSafariでは、フォントサイズが16px未満の入力フィールドをタップすると自動ズームが発生する仕様があるため、CSSでのフォントサイズ調整ではなく、viewportのmaximum-scaleで制御する方法を採用
ただ、
この変更の方法はアクセシビリティ違反に該当するため、検討の必要がある

【参考】
https://developer.mozilla.org/ja/docs/Web/HTML/Guides/Viewport_meta_element#maximum-scale