### PR TITLE
fix: タブを高速に切り替えると、うまく切り替わらないことがある問題を修正

### DIFF
--- a/app/Http/Livewire/AdminUserTop.php
+++ b/app/Http/Livewire/AdminUserTop.php
@@ -16,8 +16,6 @@ class AdminUserTop extends Component
     public $search = '';
 
     // 各タブの表示状態を管理するプロパティ
-    public $show_users = true;
-    public $show_suspension_users = false;
     public $show_group_reports = false;
     public $show_members = false;
 
@@ -31,14 +29,6 @@ class AdminUserTop extends Component
     {
         $this->show_group_reports = false;
         $this->show_members = true;
-
-        if ($this->show_users) {
-            $this->show_users_pagination = true;
-        }
-
-        if ($this->show_suspension_users) {
-            $this->show_suspension_users_pagination = true;
-        }
     }
 
     public function updatingSearch()

--- a/app/Http/Livewire/GroupShowAdmin.php
+++ b/app/Http/Livewire/GroupShowAdmin.php
@@ -28,14 +28,6 @@ class GroupShowAdmin extends Component
     public $show_book = true;
     public $search = '';
 
-    // 各タブの表示状態を管理するプロパティ
-    public $show_group_reports = true;
-    public $show_members = false;
-    public $show_users = false;
-    public $show_users_pagination = false;
-    public $show_suspension_users = false;
-    public $show_suspension_users_pagination = false;
-
     public $isSuspended;
 
     public $deleteTargetUserId = 0;
@@ -73,20 +65,6 @@ class GroupShowAdmin extends Component
         }
 
         $this->dispatchBrowserEvent('load');
-    }
-
-    public function showMember()
-    {
-        $this->show_group_reports = false;
-        $this->show_members = true;
-
-        if ($this->show_users) {
-            $this->show_users_pagination = true;
-        }
-
-        if ($this->show_suspension_users) {
-            $this->show_suspension_users_pagination = true;
-        }
     }
 
     public function setReportReason($report_reason)

--- a/app/Http/Livewire/GroupTopAdmin.php
+++ b/app/Http/Livewire/GroupTopAdmin.php
@@ -18,10 +18,6 @@ class GroupTopAdmin extends Component
     public $sortCriteria = 'report';
     public $search = '';
 
-    // 各タブの表示状態を管理するプロパティ
-    public $show_groups = true;
-    public $show_suspension_groups = false;
-
     public function checkSuspension($skip = false)
     {
         // 指定のメソッドの最初でこのメソッドを呼び出すと、利用停止中ユーザーはそのメソッドを利用できない

--- a/app/Http/Livewire/MemberEdit.php
+++ b/app/Http/Livewire/MemberEdit.php
@@ -20,10 +20,6 @@ class MemberEdit extends Component
 
     public $is_manager = false;
 
-    // 各タブの表示状態を管理するプロパティ
-    public $show_members = true;
-    public $show_block_members = false;
-
     public function getListeners()
     {
         return [

--- a/app/Http/Livewire/MemoListMypage.php
+++ b/app/Http/Livewire/MemoListMypage.php
@@ -25,11 +25,6 @@ class MemoListMypage extends Component
     public $selected_labels = [];
     public $search = '';
 
-    // 各タブの表示状態を管理するプロパティ
-    public $show_my_memos = true;
-    public $show_good_memos = false;
-    public $show_later_read_memos = false;
-
     protected $listeners = [
         'setGroupId',
         'filterByWebBookLabels',

--- a/app/Http/Livewire/UserShow.php
+++ b/app/Http/Livewire/UserShow.php
@@ -28,11 +28,6 @@ class UserShow extends Component
     public $selected_labels = [];
     public $search = '';
 
-    // 各タブの表示状態を管理するプロパティ
-    public $show_users = true;
-    public $show_memos = false;
-    public $show_comments = false;
-
     public $isSuspended;
 
     public $deleteTargetUserId = 0;

--- a/app/Http/Livewire/UserTopAdmin.php
+++ b/app/Http/Livewire/UserTopAdmin.php
@@ -21,9 +21,6 @@ class UserTopAdmin extends Component
     public $sortCriteria = 'report_all';
     public $search = '';
 
-    public $show_user = true;
-    public $show_suspended_user = false;
-
     public $deleteTargetUserId = 0;
     public $targetGroup;
     public $fragSubManagerOrMember = '';

--- a/resources/views/livewire/admin-user-top.blade.php
+++ b/resources/views/livewire/admin-user-top.blade.php
@@ -1,6 +1,6 @@
 <div x-data="{
-    user: @entangle('show_users'),
-    suspension_user: @entangle('show_suspension_users'),
+    user: true,
+    suspension_user: false,
 }">
     <x-slot name="header">
         <h2 class="font-semibold leading-tight text-gray-800">

--- a/resources/views/livewire/group-show-admin.blade.php
+++ b/resources/views/livewire/group-show-admin.blade.php
@@ -1,10 +1,10 @@
 <div x-data="{
-    group_report: @entangle('show_group_reports'),
-    member: @entangle('show_members'),
-    user: @entangle('show_users'),
-    suspension_user: @entangle('show_suspension_users'),
-    user_pagination: @entangle('show_users_pagination'),
-    suspension_user_pagination: @entangle('show_suspension_users_pagination'),
+    group_report: true,
+    member: false,
+    user: true,
+    suspension_user: false,
+    user_pagination: false,
+    suspension_user_pagination: false,
     showNextManagerModal: @entangle('showNextManagerModal'),
     showModalNobodyMember: @entangle('showModalNobodyMember'),
 }" wire:init="$refresh">
@@ -112,15 +112,15 @@
                 {{-- グループ通報情報 / メンバー 選択--}}
                 <div class="mx-3 mb-10 border-b border-gray-400">
                     <div class="flex text-xs font-bold lg:text-sm lg:w-1/2">
-                        <button
+                        <button type="button"
                             class="w-1/2 text-center rounded-t-xl transition duration-700 ease-in-out hover:bg-blue-100"
-                            type="button"
                             x-on:click="group_report = true; member=false; user_pagination = false; suspension_user_pagination = false"
                             x-bind:class="group_report ? 'border-b-4 border-blue-300' :'' ">
                             <p>グループ通報情報</p>
                         </button>
-                        <button wire:click="showMember"
+                        <button type="button"
                             class="w-1/2 text-center rounded-t-xl transition duration-700 ease-in-out hover:bg-blue-100"
+                            x-on:click="member = true; group_report = false; user_pagination = true; suspension_user_pagination = false"
                             x-bind:class="member ? 'border-b-4 border-blue-300' :'' ">
                             <p>メンバー</p>
                         </button>

--- a/resources/views/livewire/group-top-admin.blade.php
+++ b/resources/views/livewire/group-top-admin.blade.php
@@ -1,6 +1,6 @@
 <div x-data="{
-    group: @entangle('show_groups'),
-    suspension_group: @entangle('show_suspension_groups'),
+    group: true,
+    suspension_group: false,
 }">
     <x-slot name="header">
         <h2 class="font-semibold leading-tight text-gray-800">

--- a/resources/views/livewire/member-edit.blade.php
+++ b/resources/views/livewire/member-edit.blade.php
@@ -1,6 +1,6 @@
 <div x-data="{
-    member: @entangle('show_members'),
-    block_member: @entangle('show_block_members'),
+    member: true,
+    block_member: false,
 }">
     <x-slot name="header">
         <h2 class="font-semibold leading-tight text-gray-800">

--- a/resources/views/livewire/memo-list-mypage.blade.php
+++ b/resources/views/livewire/memo-list-mypage.blade.php
@@ -1,8 +1,10 @@
-<div x-data="{
-    my_memo: @entangle('show_my_memos'),
-    good_memo: @entangle('show_good_memos'),
-    later_read_memo: @entangle('show_later_read_memos')
-}">
+<div
+x-data="{
+    my_memo: true,
+    good_memo: false,
+    later_read_memo: false
+}"
+>
     <x-slot name="header">
         <div class="flex">
             <h2 class="font-semibold leading-tight text-gray-800">
@@ -80,19 +82,19 @@
                     <div class="flex text-xs font-bold lg:text-sm xl:w-1/2">
                         <button
                             class="w-1/2 text-center rounded-t-xl transition duration-700 ease-in-out hover:bg-blue-100"
-                            type="button" x-on:click="my_memo = true; good_memo=false; later_read_memo=false"
+                            type="button" x-on:click="my_memo = true; good_memo=false; later_read_memo=false; $wire.$refresh()"
                             x-bind:class="my_memo ? 'border-b-4 border-blue-300' :'' ">
                             <p>自分が作成したメモ</p>
                         </button>
                         <button
                             class="w-1/2 text-center rounded-t-xl transition duration-700 ease-in-out hover:bg-blue-100"
-                            type="button" x-on:click="my_memo = false; good_memo=true; later_read_memo=false"
+                            type="button" x-on:click="my_memo = false; good_memo=true; later_read_memo=false; $wire.$refresh()"
                             x-bind:class="good_memo ? 'border-b-4 border-blue-300' :'' ">
                             <p>いいねしたメモ</p>
                         </button>
                         <button
                             class="w-1/2 text-center rounded-t-xl transition duration-700 ease-in-out hover:bg-blue-100"
-                            type="button" x-on:click="my_memo = false; good_memo=false; later_read_memo=true"
+                            type="button" x-on:click="my_memo = false; good_memo=false; later_read_memo=true; $wire.$refresh()"
                             x-bind:class="later_read_memo ? 'border-b-4 border-blue-300' :'' ">
                             <p>あとでよむしたメモ</p>
                         </button>

--- a/resources/views/livewire/user-show.blade.php
+++ b/resources/views/livewire/user-show.blade.php
@@ -1,7 +1,7 @@
 <div x-data="{
-    user: @entangle('show_users'),
-    memo: @entangle('show_memos'),
-    comment: @entangle('show_comments'),
+    user: true,
+    memo: false,
+    comment: false,
     showNextManagerModal: @entangle('showNextManagerModal'),
     showModalNobodyMember: @entangle('showModalNobodyMember'),
 }" wire:init="$refresh">

--- a/resources/views/livewire/user-top-admin.blade.php
+++ b/resources/views/livewire/user-top-admin.blade.php
@@ -1,12 +1,10 @@
 <div x-data="{
-    user: @entangle('show_user'),
-    suspended_user: @entangle('show_suspended_user'),
+    user: true,
+    suspended_user: false,
     showNextManagerModal: @entangle('showNextManagerModal'),
     showModalNobodyMember: @entangle('showModalNobodyMember'),
 }">
-    {{-- <div class="fixed inset-0 z-40 bg-gray-100 bg-opacity-40">
-        <div class="absolute inset-0 m-auto w-10 h-10 bg-red-500"></div>
-    </div> --}}
+
     <x-slot name="header">
         <h2 class="font-semibold leading-tight text-gray-800">
             ユーザー一覧


### PR DESCRIPTION
## やったこと

* マイページのタブ切り替え機能を@entangleを使った実装からAlpine.js独立の状態管理に変更
* マイページに関しては、タブ切り替え時にLivewireコンポーネントのリフレッシュ（`$wire.$refresh()`）を追加

## やらないこと

* app/Http/Livewire/AdminUserTop.php内の、今回の修正とは直接関係ないデッドコードの削除（別のプルリクでやる）

## できるようになること（ユーザ目線）

* 高速でタブ切り替えを行っても確実にタブの切り替えができる

## できなくなること（ユーザ目線）

* 無し

## 動作確認

* **高速タブ切り替えテスト**: 素早く連続でタブをクリックしても、複数のタブが選択状態になることなく、正常に1つのタブのみが選択される（目視）
* **いいね後のタブ切り替えテスト**: 「自分が作成したメモ」タブでメモにいいねを押し、「いいねしたメモ」タブに切り替えると、そのメモが正しく表示される（目視）
* **あとでよむ後のタブ切り替えテスト**: 「自分が作成したメモ」タブでメモを「あとでよむ」に追加し、「あとでよむしたメモ」タブに切り替えると、そのメモが正しく表示される（目視）

## その他

* **技術的な改善点**: @entangleによる双方向バインディングで発生していた非同期処理の競合状態（Race Condition）を解決
* **パフォーマンス**: フロント側でタブの状態管理をすることにより、不要な通信を削減
* **今回の方法を採用する理由**: 変更前の方法（@entangleを使用してLivewireコンポーネント側で状態管理する）だと、タブ切り替えの際にサーバーとの通信が発生し、高速な切り替えに画面が追いつかないと考えられるため、早く切り替える必要がある部分に関しては状態管理をalpine.jsで完結する形にする