### PR TITLE
feat: ソーシャルログイン失敗時のエラーメッセージを改善

### DIFF
--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -32,7 +32,8 @@ class LoginController extends Controller
                 // セッションをクリアしてリダイレクト
                 session()->flush();
 
-                return redirect()->route('login')->with('error', 'このGoogleアカウントでの連携情報がありません');
+                return redirect()->route('login')
+                    ->with('error', "このGoogleアカウントでの連携情報がありません。\nプロフィール画面からソーシャルログイン設定をしてください。");
             }
         } catch (\Exception $e) {
             Log::error('Google login error: '.$e->getMessage());


### PR DESCRIPTION
## やったこと

* Googleログイン時の未連携アカウントエラーメッセージを改善

## やらないこと

* 無し

## できるようになること（ユーザ目線）

* Googleアカウントが未連携の場合、具体的な解決方法がエラーメッセージで分かるようになる

## できなくなること（ユーザ目線）

* 無し

## 動作確認

* 未連携のGoogleアカウントでログインを試行し、改善されたエラーメッセージが表示されることを確認
* エラーメッセージに改行が正しく含まれ、読みやすい形式で表示されることを確認

## その他

* 無し