### PR TITLE
chore: ゲストユーザーのダミーデータを作成

### DIFF
--- a/database/seeders/UserSeeder.php
+++ b/database/seeders/UserSeeder.php
@@ -498,6 +498,30 @@ class UserSeeder extends Seeder
                 'created_at' => Carbon::now(),
                 'updated_at' => Carbon::now(),
             ],
+            [
+                'email' => 'basta.guestuser+1@gmail.com',
+                'password' => Hash::make('#LwDaL1@13X5CBt4biy'),
+                'nickname' => 'ゲストユーザー1',
+                'suspension_state' => 0,
+                'created_at' => Carbon::now(),
+                'updated_at' => Carbon::now(),
+            ],
+            [
+                'email' => 'basta.guestuser+2@gmail.com',
+                'password' => Hash::make('#LwDaL1@13X5CBt4biy'),
+                'nickname' => 'ゲストユーザー2',
+                'suspension_state' => 0,
+                'created_at' => Carbon::now(),
+                'updated_at' => Carbon::now(),
+            ],
+            [
+                'email' => 'basta.guestuser+3@gmail.com',
+                'password' => Hash::make('#LwDaL1@13X5CBt4biy'),
+                'nickname' => 'ゲストユーザー3',
+                'suspension_state' => 0,
+                'created_at' => Carbon::now(),
+                'updated_at' => Carbon::now(),
+            ],
         ];
 
         foreach ($users as $user) {


### PR DESCRIPTION
## やったこと

* UserSeederにゲストユーザー用のダミーデータを3件追加した（GitHubのREADMEに記載する用）

## やらないこと

* 無し

## できるようになること（ユーザ目線）

* GitHubのREADMEを見たユーザーが、ゲストユーザーアカウントを使用した動作確認ができるようになる

## できなくなること（ユーザ目線）

* 無し

## 動作確認

* 追加されたゲストユーザーでログインできることを確認

## その他

* 無し